### PR TITLE
Flags for search defined. Movie Struct also defined

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -26,7 +26,7 @@ to quickly create a Cobra application.`,
 }
 
 func init() {
-	rootCmd.AddCommand(configCmd)
+	yastCmd.AddCommand(configCmd)
 
 	// Here you will define your flags and configuration settings.
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,10 +10,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-
-
-// rootCmd represents the base command when called without any subcommands
-var rootCmd = &cobra.Command{
+// yastCmd represents the base command when called without any subcommands
+// renaming rootCmd to yastCmd for better Context
+var yastCmd = &cobra.Command{
 	Use:   "yast",
 	Short: "A brief description of your application",
 	Long: `A longer description that spans multiple lines and likely contains
@@ -30,7 +29,7 @@ to quickly create a Cobra application.`,
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	err := rootCmd.Execute()
+	err := yastCmd.Execute()
 	if err != nil {
 		os.Exit(1)
 	}
@@ -45,7 +44,5 @@ func init() {
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	//yastCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }
-
-

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -5,9 +5,10 @@ Copyright © 2022 NAME HERE <EMAIL ADDRESS>
 package cmd
 
 import (
-	"fmt"
 
+	"fmt"
 	"github.com/spf13/cobra"
+	//"github.com/qascade/yast/core"
 )
 
 // searchCmd represents the search command
@@ -20,20 +21,68 @@ and usage of using your command. For example:
 Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("search called")
-	},
+	Run: Search, 
+}
+//Flags for searchCmd
+var MovieName string
+var SeriesName string
+var MovieSet bool
+var SeriesSet bool
+// For now we will only search for either movie or series one at a time. If both flags set throw error
+var BothSet bool
+
+func CheckIfSet(cmd *cobra.Command, args []string) (movieSet, seriesSet, bothSet bool, err error){
+	if cmd.Flag("movie").Changed {
+		movieSet = true
+	}
+	if cmd.Flag("series").Changed {
+		seriesSet = true
+	}
+	if cmd.Flag("movie").Changed  && cmd.Flag("series").Changed {
+		bothSet = true
+	}
+	if !movieSet && !seriesSet {
+		err = fmt.Errorf("you must specify either a movie or a series to search for")
+	}
+	return
 }
 
-func init() {
-	rootCmd.AddCommand(searchCmd)
+func Search(cmd *cobra.Command, args []string){
+	var err error
+	MovieSet, SeriesSet, BothSet, err = CheckIfSet(cmd, args)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	if BothSet {
+		fmt.Println("You can only search for either movie or series at a time")
+		return
+	}
+	if MovieSet {
+		MovieName = cmd.Flag("movie").Value.String()
+		fmt.Println("Searching for movie: ", MovieName)
+	}
+	if SeriesSet {
+		SeriesName = cmd.Flag("series").Value.String()
+		fmt.Println("Searching for series: ", SeriesName)
+	}
+}
+	
 
+// func SearchMovie(movieName string, targetSite url) (error){
+	
+// }
+
+func init() {
+	yastCmd.AddCommand(searchCmd)
+	
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command
 	// and all subcommands, e.g.:
 	// searchCmd.PersistentFlags().String("foo", "", "A help for foo")
-
+	searchCmd.Flags().StringVarP(&MovieName, "movie", "m", "", "name of the movie to be searched")
+	searchCmd.Flags().StringVar(&SeriesName, "series", "", "name of the series to be searched")
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// searchCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -26,7 +26,7 @@ to quickly create a Cobra application.`,
 }
 
 func init() {
-	rootCmd.AddCommand(setupCmd)
+	yastCmd.AddCommand(setupCmd)
 
 	// Here you will define your flags and configuration settings.
 

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,9 @@ module github.com/qascade/yast
 
 go 1.18
 
+require github.com/spf13/cobra v1.5.0
+
 require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/spf13/cobra v1.5.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 )


### PR DESCRIPTION
Two flags for yast search are defined. The flags are:
1. --movie or -m
2. --series , shorthand not defined for now as shorthand only allows
single character
For user can only search for a movie or series at once.
Defined Movie Structure in core Package which will contain the Movie and
Series Struct.
Series Struct yet to be defined.